### PR TITLE
Update WideImage/Image.php

### DIFF
--- a/WideImage/Image.php
+++ b/WideImage/Image.php
@@ -1,26 +1,26 @@
 <?php
 	/**
- * @author Gasper Kozak
- * @copyright 2007-2011
+	 * @author Gasper Kozak
+	 * @copyright 2007-2011
 
-    This file is part of WideImage.
+	 This file is part of WideImage.
+	
+	 WideImage is free software; you can redistribute it and/or modify
+	 it under the terms of the GNU Lesser General Public License as published by
+	 the Free Software Foundation; either version 2.1 of the License, or
+	 (at your option) any later version.
 		
-    WideImage is free software; you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published by
-    the Free Software Foundation; either version 2.1 of the License, or
-    (at your option) any later version.
+	 WideImage is distributed in the hope that it will be useful,
+	 but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 GNU Lesser General Public License for more details.
 		
-    WideImage is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
-		
-    You should have received a copy of the GNU Lesser General Public License
-    along with WideImage; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+	 You should have received a copy of the GNU Lesser General Public License
+	 along with WideImage; if not, write to the Free Software
+	 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	* @package WideImage
-  **/
+	**/
 	
 	/**
 	 * Thrown when an invalid dimension is passed for some operations
@@ -216,7 +216,13 @@
 			$args = func_get_args();
 			$data = call_user_func_array(array($this, 'asString'), $args);
 			
-			$this->writeHeader('Content-length', strlen($data));
+			if (function_exists('mb_strlen')) {
+				$byteCount = mb_strlen($data, '8bit');
+			} else {
+				$byteCount = strlen($data);
+			}
+			
+			$this->writeHeader('Content-length', $byeCount);
 			$this->writeHeader('Content-type', WideImage_MapperFactory::mimeType($format));
 			echo $data;
 		}


### PR DESCRIPTION
Apparently some setups have `mbstring` overloading enabled for transparent UTF support, which affects the behaviour of `strlen`.

Not sure how this would affect binary files but suggest this change based on solution here:

http://stackoverflow.com/questions/3511106/filesize-from-a-string

Also tidied up some tab vs spaces whitespace issues at top of file. Nice component, by the way.
